### PR TITLE
Resize clickable range of prev/next buttons

### DIFF
--- a/src/style/widescreenMode.less
+++ b/src/style/widescreenMode.less
@@ -382,12 +382,14 @@ body[class] {
         }
 
         .stream-prev {
-          padding: 0 0 0 20px !important;
+          padding: 100% 30px 100% 30px !important;
+          z-index: 4;
         }
 
         .stream-next {
           right: 20px;
-          padding: 0 5px !important
+          padding: 100% 30px 100% 30px !important;
+          z-index: 4;
         }
 
         .video-controls {


### PR DESCRIPTION
## General
**Type:** (Improvement) 

**Module:** Widescreen Mode

## Changes
Resize the clickable range of previous / next post buttons since the usability for mouse navigation is quite bad. One small misalignment of the cursor and the overlay closes. 
With this implementation the Button is clickable at the full height while still allow media controls to be clickable. However, there is also enough space to close the overlay. 
While the padding could be smaller in size from a usability perspective it is perfect to use the full screen height as it is done by other software aswell. 

![Picture of the clickable range](https://i.imgur.com/gooLHzv.png)
