### PR TITLE
Remove jQuery tooltip (fixes #35)

### DIFF
--- a/src/module/AdvancedComments.js
+++ b/src/module/AdvancedComments.js
@@ -40,7 +40,6 @@ export default class AdvancedComments {
             }
 
             const comments = $('.comments .comment-box .comment');
-            comments.tooltip();
             for (let i = 0; i < comments.length; i++) {
                 const container = $(comments[i]);
                 const comment = $(container.parents('.comment-box')[0]).prev('.comment');

--- a/src/style/advancedComments.less
+++ b/src/style/advancedComments.less
@@ -93,12 +93,3 @@
     color: #ee4d2e;
   }
 }
-
-.ui-tooltip {
-  position: absolute;
-  z-index: 9999;
-  padding: 10px;
-  background-color: #2a2e31;
-  border: 2px solid #252525;
-  max-width: 30vw;
-}


### PR DESCRIPTION
## General
**Type:** Fix

**Module:** Advanced Comments

## Changes
jQuery Tooltip entfernt. Ist die einzige Stelle, an der der Tooltip überhaupt verwendet wird, daher auch konsistent mit dem Rest.
