### PR TITLE
Rework How Viewed Posts behave

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "p0weruser",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -711,6 +711,14 @@
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+          "dev": true
+        }
       }
     },
     "buffer": {
@@ -3842,10 +3850,9 @@
       "dev": true
     },
     "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "parallel-transform": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "chart.js": "^2.9.4",
         "core-js": "^2.6.11",
         "moment": "^2.25.3",
+        "pako": "^2.0.4",
         "simplebar": "^2.6.1",
         "tesseract.js": "^1.0.19",
         "webpack-bundle-analyzer": "^3.7.0"

--- a/src/module/ViewedPostsMarker.js
+++ b/src/module/ViewedPostsMarker.js
@@ -10,7 +10,7 @@ export default class ViewedPostsMarker {
     }
 
     load() {
-        let _this = this;
+        const _this = this;
         this.styles = require('../style/viewedPostsMarker.less');
         this.viewedPosts = ViewedPostsMarker.getViewedPosts();
 
@@ -47,7 +47,7 @@ export default class ViewedPostsMarker {
     }
 
     static markAsViewed(id) {
-        let elem = document.getElementById('item-' + id);
+        const elem = document.getElementById('item-' + id);
 
         if (elem) {
             elem.classList.add('viewed');
@@ -55,7 +55,7 @@ export default class ViewedPostsMarker {
     }
 
     static getViewedPosts() {
-        let posts = Settings.get('viewed_posts');
+        const posts = Settings.get('viewed_posts');
 
         if (posts === true) {
             return [];

--- a/src/module/ViewedPostsMarker.js
+++ b/src/module/ViewedPostsMarker.js
@@ -20,10 +20,16 @@ export default class ViewedPostsMarker {
              * it should be fired. This is the case for every event which accesses items.
              */
             if(settings.url.startsWith('/api/items/get')) {
-                if(this.markOwnFavoritesAsViewed || !(await this.wouldLoadUserCollection(settings.url))) {   
-                    this.viewedPosts.forEach(post => {
-                        ViewedPostsMarker.markAsViewed(post);
-                    });
+                if(this.markOwnFavoritesAsViewed || !(await this.wouldLoadUserCollection(settings.url))) {
+                    if(request.responseJSON.items.length > 0) {
+                        const loadedItems = request.responseJSON.items.map(item => item.id);
+                        
+                        // Intersect loaded and viewed items
+                        loadedItems.filter(item => this.viewedPosts.includes(item))
+                            .forEach(post => {
+                                ViewedPostsMarker.markAsViewed(post);
+                            });
+                    }
                 }
             }
         });


### PR DESCRIPTION
Basiert auf #52 

## General
**Type:** Improvement

**Module:** ViewedPostMarker

## Changes
Vorher: 
Array mit IDs, würde bei ~8 Mio IDs problematisch werden. LocalStorage von Firefox lässt bspw. nur 10MB pro Origin zu.

Jetzt: 
Bitmap verwendet. Index: Post-ID, Wert: Gesehen ja/nein.

Eine Migration vorhandener Daten findet statt.
An Performance muss noch gearbeitet werden, ist aber grundsätzlich funktionsfähig. 

Der Speicherbedarf kann so um rund 80% gesenkt werden. 10.000 Gesehene Posts benötigen nur ~18kB Speicher, wohingegen die Alte Implementierung ~80kB schluckt. 