### PR TITLE
Override next/prev functions to prevent site from scrolling (Fixes #42)

### DIFF
--- a/src/module/WidescreenMode.js
+++ b/src/module/WidescreenMode.js
@@ -306,6 +306,30 @@ export default class WidescreenMode {
 
             return `<div class="item-row">${result}</div>`;
         };
+
+        // Override next - original code - adjustments are commented
+        p.View.Stream.Main.prototype.next = function (ev) {
+            var $next = this.getNextItem(this.$currentItem);
+            if (!$next.length) {
+                return false;
+            }
+            // Dont use a scrollTo value, to prevent the page from scrolling
+            this.showItem($next, null);
+            p.navigateTo($next.attr('href').substr(1), p.NAVIGATE.SILENT);
+            return false;
+        };
+
+        // Override prev - original code - adjustments are commented
+        p.View.Stream.Main.prototype.prev = function (ev) {
+            var $prev = this.getPrevItem(this.$currentItem);
+            if (!$prev.length) {
+                return false;
+            }
+            // Dont use a scrollTo value, to prevent the page from scrolling
+            this.showItem($next, null);
+            p.navigateTo($prev.attr('href').substr(1), p.NAVIGATE.SILENT);
+            return false;
+        };
     }
 
     calculateBenisUntilTop(up, down, date) {


### PR DESCRIPTION
## General
**Type:** Fix

**Module:** Widescreen Mode

## Changes
Unterbinden, dass Seite beim Bildwechsel scrollt, was Standard pr0gramm-verhalten ist.
Weiß noch nicht ob es ne bessere Möglichkeit gibt, könnte halt breaken, sobald pr0 entscheidet die Funktionen abzuändern.
