### PR TITLE
Resize stream based on screen width using float container

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "TamperMonkey",
         "pr0gramm"
     ],
-    "version": "1.7.9",
+    "version": "1.7.10",
     "license": "GPL-3.0",
     "dependencies": {
         "chart.js": "^2.9.4",

--- a/src/style/viewedPostsMarker.less
+++ b/src/style/viewedPostsMarker.less
@@ -22,8 +22,9 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      height: inherit;
-      width: inherit;
+      // Removed in favor of floating stream in widescreen mode
+      // height: inherit;
+      // width: inherit;
       border: none !important;
     }
 

--- a/src/style/widescreenMode.less
+++ b/src/style/widescreenMode.less
@@ -38,13 +38,25 @@ body[class] {
         display: block;
         margin: 0 auto;
 
-        a.thumb {
-          display: inline-block;
-          float: left;
-        }
-
         .stream-row {
           clear: none;
+        }
+
+        .item-row {
+          display: flex;
+          flex-wrap: wrap;
+
+          a.thumb {
+            img {
+              width: 100%;
+            }
+            flex: 1 1 128px;
+            background-color: transparent;
+            margin: 0;
+            width: auto;
+            height: auto;
+            margin: 1px; // Looks more "natural" with margin
+          }
         }
       }
     }


### PR DESCRIPTION
## General
**Type:** Improvement
Resolves #67 

**Module:** Widescreen Mode und ViewedPostMarker

## Changes
Hab den Stream in ein Float gepackt, der die Kacheln resized, sodass die breite des Bildschirms immer ausgefüllt wird

Beim Testen sind noch einige Probleme aufgefallen, die aber nicht durch die Änderung kommen:
- Beim Resizen des Fensters werden Viewed Posts resettet (Weil Klasse entfernt wird)
- Beim Resizen des Fensters wird random der zuletzt betrachtete Post angezeigt

Kümmer mich noch drum, ob ich das in den Griff bekomme, hat aber nichts mit dem Feature zu tun. Desweiteren hab ich das Ding noch nicht komplett getestet.