### PR TITLE
highlight comment on direct link (fixes #93)

### DIFF
--- a/src/P0weruser.ts
+++ b/src/P0weruser.ts
@@ -3,40 +3,39 @@ import EventHandler from './EventHandler';
 import { PoweruserModule } from './types';
 import Settings from './core/Settings/Settings';
 import { modules } from './module';
+import StateStore from "./core/StateStroe/StateStore";
 
-const allModules = Object.values(modules)
-    .map(m => m());
+const allModules = Object.values(modules).map((m) => m());
 
 const getActivatedModules = (): PoweruserModule[] => {
-    const setting = window.localStorage.getItem('activated_modules');
-    if (setting === null) {
-        window.localStorage.setItem('activated_modules', '[]');
-        Settings.addHint();
-        return [];
-    }
-    const activeModuleIds: string[] = JSON.parse(setting);
-    return allModules
-        .filter(m => activeModuleIds.includes(m.id));
-}
-
-
-const loadModule = async (module: PoweruserModule) => {
-    await module.load();
-    console.debug(`Loaded module: ${module.id}`);
-}
-const loadModules = async (modulesToLoad: PoweruserModule[]) => Promise.all(modulesToLoad.map(m => loadModule(m)));
-const addStyles = () => {
-    // FontAwesome (Icons)
-    let fa = document.createElement('link');
-    fa.type = 'text/css';
-    fa.rel = 'stylesheet';
-    fa.href = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css';
-    document.getElementsByTagName('head')[0].appendChild(fa);
-
-    let scrollbar = document.createElement('style');
-    document.getElementsByTagName('head')[0].appendChild(scrollbar);
+  const setting = window.localStorage.getItem("activated_modules");
+  if (setting === null) {
+    window.localStorage.setItem("activated_modules", "[]");
+    Settings.addHint();
+    return [];
+  }
+  const activeModuleIds: string[] = JSON.parse(setting);
+  return allModules.filter((m) => activeModuleIds.includes(m.id));
 };
 
+const loadModule = async (module: PoweruserModule) => {
+  await module.load();
+  console.debug(`Loaded module: ${module.id}`);
+};
+const loadModules = async (modulesToLoad: PoweruserModule[]) =>
+  Promise.all(modulesToLoad.map((m) => loadModule(m)));
+const addStyles = () => {
+  // FontAwesome (Icons)
+  let fa = document.createElement("link");
+  fa.type = "text/css";
+  fa.rel = "stylesheet";
+  fa.href =
+    "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css";
+  document.getElementsByTagName("head")[0].appendChild(fa);
+
+  let scrollbar = document.createElement("style");
+  document.getElementsByTagName("head")[0].appendChild(scrollbar);
+};
 
 const activatedModules = getActivatedModules();
 
@@ -45,26 +44,25 @@ new EventHandler();
 new Settings(allModules, activatedModules);
 addStyles();
 if (activatedModules.length > 0) {
-    loadModules(activatedModules);
+  loadModules(activatedModules);
 
-    // Maybe we have added some view routes, therefore moving the 404 view to the end. If there is more particular ordering 
-    // necessary it must be done in the module.
-    const route404 = p._routes.find(r => String(r.rule) === "/(.*)/");
-    const route404Index = p._routes.indexOf(route404);
-    p._routes.push(p._routes.splice(route404Index, 1)[0]);
+  // Maybe we have added some view routes, therefore moving the 404 view to the end. If there is more particular ordering
+  // necessary it must be done in the module.
+  const route404 = p._routes.find((r) => String(r.rule) === "/(.*)/");
+  const route404Index = p._routes.indexOf(route404);
+  p._routes.push(p._routes.splice(route404Index, 1)[0]);
 
+  // Once the modules are loaded we need to trigger re-rendering again as we may have overridden views.
+  // We use force navigation here to trigger re-rendering as we're not changing location.
+  // As the native pr0gramm initializes first a view is already created. However, It is necessary that we let
+  // pr0gramm think we don't have a view yet as otherwise it will try to hide the current view.
+  if (activatedModules.some((m) => m.needsReRendering)) {
+    setTimeout(() => {
+      p.currentView = null;
 
-    // Once the modules are loaded we need to trigger re-rendering again as we may have overridden views.
-    // We use force navigation here to trigger re-rendering as we're not changing location.
-    // As the native pr0gramm initializes first a view is already created. However, It is necessary that we let 
-    // pr0gramm think we don't have a view yet as otherwise it will try to hide the current view.
-    if (activatedModules.some(m => m.needsReRendering)) {
-        setTimeout(() => {
-            p.currentView = null;
-
-            // TODO: The navigation will not work for comment links. It works but the comment is not shown as the 
-            // location is being stripped down on the post id.
-            p.navigateTo(p.location, p.NAVIGATE.FORCE);
-        }, 0);
-    }
+      // We navigate using the full URL to ensure that the view is re-rendered with all parameters.
+      // If we would use p.location, some URL parts will be trimmed down, for example the ":comment" suffix.
+      p.navigateTo(p.getURL(), p.NAVIGATE.FORCE);
+    }, 0);
+  }
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -21,36 +21,37 @@ export type ModuleSetting = {
 export type FlagName = 'sfw' | 'nsfw' | 'nsfl';
 
 export type P = {
-    _routes: any[];
-    currentView: any;
-    NAVIGATE: {
-        DEFAULT: 0;
-        SILENT: 1;
-        FORCE: 2;
+  _routes: any[];
+  currentView: any;
+  NAVIGATE: {
+    DEFAULT: 0;
+    SILENT: 1;
+    FORCE: 2;
+  };
+  location: string;
+  user: User;
+  mainView: any;
+  Stream: Stream;
+  View: {
+    Stream: {
+      Main: StreamMainView;
+      Item: BaseView & any;
+      Comments: BaseView & any;
     };
-    location: string;
-    user: User;
-    mainView: any;
-    Stream: Stream;
-    View: {
-        Stream: {
-            Main: StreamMainView;
-            Item: BaseView & any;
-            Comments: BaseView & any;
-        };
-        Base: BaseView;
-        Overlay: BaseView & any;
-        InboxMessages: any;
-        Settings: any;
-        P0weruserSettings: any;
-    };
-    reload(): any;
-    api: any;
-    shouldShowScore: (thing: any) => any;
-    navigateTo: (location: any, mode?: any) => any;
-    addRoute: (viewClass: any, path: any) => any;
-    merge: (a: any, b: any) => any;
-    mobile: boolean;
+    Base: BaseView;
+    Overlay: BaseView & any;
+    InboxMessages: any;
+    Settings: any;
+    P0weruserSettings: any;
+  };
+  reload(): any;
+  api: any;
+  shouldShowScore: (thing: any) => any;
+  navigateTo: (location: any, mode?: any) => any;
+  addRoute: (viewClass: any, path: any) => any;
+  merge: (a: any, b: any) => any;
+  getURL(): string;
+  mobile: boolean;
 };
 
 export type Stream = {


### PR DESCRIPTION
## General
**Type:** Fix

**Module:** WidescreenMode

## Changes
We navigate using the full URL to ensure that the view is re-rendered with all parameters. If we would use p.location, some URL parts will be trimmed down, for example the ":comment" suffix. This way we are able to highlight a comment, when it is accessed using direct link
