### PR TITLE
added padding to statistics in navigation bar

### DIFF
--- a/src/module/StatisticsInNavbar/StatisticsLinkInNavbar.ts
+++ b/src/module/StatisticsInNavbar/StatisticsLinkInNavbar.ts
@@ -18,6 +18,7 @@ export default class StatisticsLinkInNavbar implements PoweruserModule{
         elem.id = "user-link-stats";
         elem.appendChild(text);
         elem.setAttribute('href', 'https://pr0gramm.com/userstats');
+        elem.setAttribute("style", "padding-left: 8px");
 
         this.target.appendChild(elem);
     }


### PR DESCRIPTION
## General
**Type:** Improvement

**Module:** StatisticsLinkInNavbar

## Changes
Ich habe ein padding-left hinzugefügt für die Verlinkung zu den Statistiken in der Navigation-Bar, weil das Icon für die Einstellungen und der Link zu den Statistiken viel zu nah beieinander waren.
Sieht meiner Meinung nach deutlich besser aus, da es sonst so aus aussieht, als wäre das Einstellungs-Icon ein Teil der Verlinkung zu den Statistiken (ähnlich wie bei dem Icon für die Nachrichten links daneben).
<br>Vorher:
![before](https://user-images.githubusercontent.com/27505801/218880035-750cb62a-e63a-4e0b-bbaa-204cd26f693f.png)

Nachher:
![after](https://user-images.githubusercontent.com/27505801/218880029-e87c792f-aa0d-4879-acc1-ed4a1c38c96d.png)
