### PR TITLE
padding durch margin ersetzt in StatisticsInNavbar

### DIFF
--- a/src/module/StatisticsInNavbar/StatisticsLinkInNavbar.ts
+++ b/src/module/StatisticsInNavbar/StatisticsLinkInNavbar.ts
@@ -18,7 +18,7 @@ export default class StatisticsLinkInNavbar implements PoweruserModule{
         elem.id = "user-link-stats";
         elem.appendChild(text);
         elem.setAttribute('href', 'https://pr0gramm.com/userstats');
-        elem.setAttribute("style", "padding-left: 8px");
+        elem.setAttribute("style", "margin-left: 8px");
 
         this.target.appendChild(elem);
     }


### PR DESCRIPTION
## General
**Type:** Improvement

**Module:** StatisticsInNavbar

## Changes
Habe _padding_ durch _margin_ ausgetauscht, damit das Element tatsächlich ein wenig nach rechts verschoben wird, sodass der Bereich zwischen dem Settings-Symbol und dem Statistik-Button nicht mehr anklickbar ist