### PR TITLE
Update DefaultFilters.ts

### DIFF
--- a/src/module/DefaultFilters/DefaultFilters.ts
+++ b/src/module/DefaultFilters/DefaultFilters.ts
@@ -67,7 +67,7 @@ export default class DefaultFilters implements PoweruserModule {
         if (p.location === 'top' || p.location === 'new') {
             const filter = this.getFilter();
             if (filter) {
-                const location = 'new/' + encodeURIComponent(filter);
+                const location = p.location + '/' + encodeURIComponent(filter);
                 p.navigateTo(location, p.NAVIGATE.SILENT);
             }
         }


### PR DESCRIPTION
Fixed hardcoded loading of new. It now uses current location (top or new).

## General
**Type:** Improvement

**Module:** DefaultFilters.ts

## Changes
Setting and loading default filters would only load "new". It now uses the current location, provided it is "new" or "top"
