### PR TITLE
Fix #223 #224

### DIFF
--- a/assets/template/streamItem.html
+++ b/assets/template/streamItem.html
@@ -12,7 +12,7 @@
             <div class="item-image">
                 <div class="item-image-thumb" style="background-image: url({item.thumb})"></div>
                 <?js if(supportsAutoplay) {?>
-                <video class="item-image-actual" draggable="true" loop autoplay preload="auto">
+                <video class="item-image-actual" draggable="true" loop autoplay preload="auto" crossorigin="anonymous">
                   <?js if (item.variants && item.variants.length > 0) { ?>
                   <?js for (const variant of item.variants) { ?>
                   <source src="{variant.src}" type="{{variant.mimeType}}" <?js if (variant.media) { ?> media="{{variant.media}}"
@@ -170,7 +170,7 @@
                         </a>
                     <?js } ?>
                     </span> |
-                    <span class="action copy-link" data-url="https://{CONFIG.HOST}/new/{item.id}" title="Link zum Teilen in die Zwischenablage kopieren"> Teilen</span> </span> 
+                    <span class="action copy-link" data-url="https://{CONFIG.HOST}/new/{item.id}" title="Link zum Teilen in die Zwischenablage kopieren"> Teilen</span> </span>
                     <span style="margin-right: 12px;"> | <a href="{item.image}" target="_blank" class="action">herunterladen</a> </span>
                         <?js if( p.user.admin ) { ?>
                         [<span class="action" id="item-delete" data-id="{item.id}">del</span>]

--- a/src/module/WidescreenMode/widescreenMode.less
+++ b/src/module/WidescreenMode/widescreenMode.less
@@ -243,6 +243,8 @@ body[class] {
           .item-details,
           .item-tags {
             padding: 5px 20px 5px 40px;
+            overflow: auto;
+            max-height: 15vh;
           }
 
           .item-details {


### PR DESCRIPTION
## General
**Type:** Fix

**Module:** Widescreen Mode

## Changes
#223 Fix: An dem `<video>` im Template wird nun das Attribut `crossorigin="anonymous"` gesetzt.
#224 Fix: Die CSS-Klasse `.item-tags` wird nun mit `max-height: 15vh; overflow: auto;` gestylt.
